### PR TITLE
make replies ephemeral for /check and /report

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -29,23 +29,32 @@ export async function execute(interaction: CommandInteraction) {
     );
 
     if (response.data.status === "BLOCKED") {
-      await interaction.reply(
-        `🚨 **Alert** 🚨 \n\nThis link is a scam! \`${escapedUrl}\` \n\n_Please **DO NOT** click on this link._`
-      );
+      await interaction.reply({
+        content: `🚨 **Alert** 🚨 \n\nThis link is a scam! \`${escapedUrl}\` \n\n_Please **DO NOT** click on this link._`,
+        ephemeral: true,
+      });
     } else if (response.data.status === "ALLOWED") {
-      await interaction.reply(`✅ This link looks safe! \`${escapedUrl}\``);
+      await interaction.reply({
+        content: `✅ This link looks safe! \`${escapedUrl}\``,
+        ephemeral: true,
+      });
     } else if (response.data.status === "UNKNOWN") {
-      await interaction.reply(
-        `⚠️ **Warning** ⚠️ \n\nThis link is not currently in our database: \`${escapedUrl}\` \n\n_Please be careful and **DO NOT** click on this link unless you are sure it's safe._`
-      );
+      await interaction.reply({
+        content: `⚠️ **Warning** ⚠️ \n\nThis link is not currently in our database: \`${escapedUrl}\` \n\n_Please be careful and **DO NOT** click on this link unless you are sure it's safe._`,
+        ephemeral: true,
+      });
     } else {
-      await interaction.reply(
-        `❓ We're not sure about this link. \`${escapedUrl}\``
-      );
+      await interaction.reply({
+        content: `❓ We're not sure about this link. \`${escapedUrl}\``,
+        ephemeral: true,
+      });
     }
   } catch (error) {
     // Handle errors
     console.error("error", error);
-    await interaction.reply("Error with checking link");
+    await interaction.reply({
+      content: "Error with checking link",
+      ephemeral: true,
+    });
   }
 }

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -41,12 +41,16 @@ export async function execute(interaction: CommandInteraction) {
       }
     );
 
-    await interaction.reply(
-      `✅ Thanks for submitting a report for \`${escapedUrl}\` ! \n\nWe've sent this report to the **${response.data.organization.name}** team and **ChainPatrol** to conduct a review. Once approved the report will be sent out to wallets to block.\n\nThanks for doing your part in making this space safer 🚀`
-    );
+    await interaction.reply({
+      content: `✅ Thanks for submitting a report for \`${escapedUrl}\` ! \n\nWe've sent this report to the **${response.data.organization.name}** team and **ChainPatrol** to conduct a review. Once approved the report will be sent out to wallets to block.\n\nThanks for doing your part in making this space safer 🚀`,
+      ephemeral: true,
+    });
   } catch (error) {
     // Handle errors
     console.error("error", error);
-    await interaction.reply("Error with submitting report");
+    await interaction.reply({
+      content: "Error with submitting report",
+      ephemeral: true,
+    });
   }
 }


### PR DESCRIPTION
Based on feedback from Mantle, I've made all the `/report` and `/check` responses ephemeral, meaning that they will only be visible to the Discord user that issues the slash command. They will also disappear after a while.

✅ QA'd it locally in the Mountain Top Discord server

<img width="886" alt="CleanShot 2023-04-19 at 14 39 17@2x" src="https://user-images.githubusercontent.com/8302959/233206074-b68d583d-e1a2-4c0f-8e1f-2e5a9960ffb7.png">


<img width="882" alt="CleanShot 2023-04-19 at 14 38 55@2x" src="https://user-images.githubusercontent.com/8302959/233206029-2151e6d2-3bc4-4d26-b855-322a2a8e8324.png">
