### PR TITLE
fix: interaction errors due to modal not shown within 3s timeout

### DIFF
--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -25,6 +25,13 @@ export const data = new SlashCommandBuilder()
       .setRequired(true)
   );
 
+/**
+ * This function is called when the `/report` command is executed.
+ *
+ * IMPORTANT: This function opens a modal to collect additional information from the user.
+ * It is critical that you call `interaction.showModal` as early as possible in this function
+ * to ensure that the modal is shown to the user before the 3 second timeout.
+ */
 export async function execute(interaction: CommandInteraction) {
   if (!interaction.isChatInputCommand()) {
     return;


### PR DESCRIPTION
- This fixes a bug with the `/report` command in the bot where the command would throw an error if the bot did not respond back to show the modal within 3s
- Unfortunately, you cannot call `interaction.deferReply()` if you want to run `interaction.showModal()`. Instead, you have to show the modal as early as possible
- This runs into a challenge because we want to call some APIs to prevent creating a report for an asset that is already allowed/blocked
- To get around this, I have instead move the asset status checking to run ONLY if the report creation fails. Report creation will respond back with a 400 error and at that point we can check to see if the reason is that the report is for an allowlisted/blocklisted asset.
- The logic is a bit messy now. Ideally, we would update the Create Report endpoint to actually respond back with a JSON payload that describes the reason that the report was not created and we could use that instead, but this is too large of a change for what I want to fix