### PR TITLE
Timeout Fix and Prettier Update

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,16 @@
+/**
+ * @type {import('prettier').Options}
+ */
+module.exports = {
+  printWidth: 90,
+  semi: true,
+  singleQuote: false,
+  trailingComma: "all",
+  bracketSpacing: true,
+  bracketSameLine: true,
+  importOrder: ["^@chainpatrol/(.*)$", "~/(.*)$", "~(.*)$", "^[./]"],
+  importOrderSeparation: true,
+  importOrderSortSpecifiers: true,
+  importOrderCaseInsensitive: false,
+  plugins: [require.resolve("@trivago/prettier-plugin-sort-imports")],
+};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "node-fetch": "^3.2.6",
     "pino": "^8.17.2",
     "pino-pretty": "^10.3.1",
+    "prettier": "^3.2.5",
     "zod": "^3.22.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "node-fetch": "^3.2.6",
     "pino": "^8.17.2",
     "pino-pretty": "^10.3.1",
-    "prettier": "^3.2.5",
     "zod": "^3.22.3"
   },
   "devDependencies": {
     "@types/node": "^18.0.6",
+    "prettier": "^3.2.5",
     "tsx": "^3.12.7",
     "typescript": "^5.1.6"
   },

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -55,7 +55,7 @@ export async function execute(interaction: CommandInteraction) {
   try {
     submissionInteraction = await interaction.awaitModalSubmit({
       filter: (i) => i.customId === "reportModal" && i.user.id === user.id,
-      time: 60_000,
+      time: 240_000,
     });
   } catch (error) {
     if (

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -55,7 +55,7 @@ export async function execute(interaction: CommandInteraction) {
   try {
     submissionInteraction = await interaction.awaitModalSubmit({
       filter: (i) => i.customId === "reportModal" && i.user.id === user.id,
-      time: 240_000,
+      time: 4 * 60 * 1000, // 4 minutes
     });
   } catch (error) {
     if (

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,7 @@ __metadata:
     node-fetch: ^3.2.6
     pino: ^8.17.2
     pino-pretty: ^10.3.1
+    prettier: ^3.2.5
     tsx: ^3.12.7
     typescript: ^5.1.6
     zod: ^3.22.3
@@ -2354,6 +2355,15 @@ __metadata:
     ts-node:
       optional: true
   checksum: b61f890499ed7dcda1e36c20a9582b17d745bad5e2b2c7bc96942465e406bc43ae03f270c08e60d1e29dab1ee50cb26970b5eb20c9aae30e066e20bd607ae4e4
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 2ee4e1417572372afb7a13bb446b34f20f1bf1747db77cf6ccaf57a9be005f2f15c40f903d41a6b79eec3f57fff14d32a20fb6dee1f126da48908926fe43c311
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- updated time to 4 min on modal timeout.

- was previously 1 min and did not give enough time to properly fill out report.

- can possibly update to auto-close on prolonged inactivity if we notice that a 4 min timeout produces bot resource inefficiencies