### PR TITLE
Add link monitoring feature to Discord bot

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -224,9 +224,9 @@ async function handleConnect(interaction: CommandInteraction) {
       return;
     }
 
-    // TODO: Implement connection logic
     await interaction.editReply({
-      content: "✅ Server connected to ChainPatrol successfully!",
+      content:
+        "Please visit https://app.chainpatrol.io/admin to connect your server to ChainPatrol.",
     });
   } catch (error) {
     logger.error("Error connecting to ChainPatrol:", error);

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -398,9 +398,34 @@ async function handleFeed(interaction: CommandInteraction) {
   await interaction.deferReply({ ephemeral: true });
 
   try {
-    // TODO: Implement feed channel update logic
+    const connectionStatus = await ChainPatrolApiClient.fetchDiscordGuildStatus({
+      guildId: interaction.guildId,
+    });
+
+    if (!connectionStatus?.connected) {
+      await interaction.editReply({
+        content:
+          "❌ The bot is not connected to any organization on ChainPatrol. Run `/setup connect` to connect the bot to your organization",
+      });
+      return;
+    }
+
     await interaction.editReply({
-      content: `✅ Feed channel set to ${channel.toString()} successfully!`,
+      content:
+        "Click the button below to connect your ChainPatrol organization to this channel. After connecting, you can run `/setup status` to check the status of the bot's connection",
+      components: [
+        {
+          type: ComponentType.ActionRow,
+          components: [
+            {
+              type: ComponentType.Button,
+              style: ButtonStyle.Link,
+              label: "Connect Feed",
+              url: `${env.CHAINPATROL_API_URL}/admin/connect-feed/discord?guildId=${interaction.guildId}&channelId=${channel.id}&channelName=${channel.name}`,
+            },
+          ],
+        },
+      ],
     });
   } catch (error) {
     logger.error("Error setting feed channel:", error);

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -104,10 +104,8 @@ async function handleLinkMonitoring(interaction: CommandInteraction) {
 
   // Check if user has Administrator or Manage Guild permissions
   if (
-    !interaction.memberPermissions?.has([
-      PermissionFlagsBits.Administrator,
-      PermissionFlagsBits.ManageGuild,
-    ])
+    !interaction.memberPermissions?.has(PermissionFlagsBits.Administrator) &&
+    !interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)
   ) {
     await interaction.reply({
       content:

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -153,6 +153,7 @@ async function handleLinkMonitoring(interaction: CommandInteraction) {
       content:
         "Would you like ChainPatrol to monitor this channel for suspicious links and messages across our blocklist and security network?",
       components: [row],
+      fetchReply: true,
       ephemeral: true,
     });
 

--- a/src/listeners/message-create.ts
+++ b/src/listeners/message-create.ts
@@ -24,6 +24,7 @@ interface DiscordConfig {
     isFeedEnabled: boolean;
     responseAction: "REACTION" | "NOTIFY" | "DELETE";
     moderatorChannelId: string | null;
+    monitoredChannels: string[];
   } | null;
 }
 
@@ -95,7 +96,11 @@ const isValidMessage = (message: Message): boolean => {
 
 const isValidConfig = (config: DiscordConfig["config"], channelId: string): boolean => {
   if (!config?.isMonitoringLinks) return false;
-  if (config.feedChannelId && config.feedChannelId !== channelId) return false;
+  if (
+    config.monitoredChannels.length > 0 &&
+    !config.monitoredChannels.includes(channelId)
+  )
+    return false;
   return true;
 };
 

--- a/src/listeners/message-create.ts
+++ b/src/listeners/message-create.ts
@@ -4,6 +4,8 @@ import {
   ButtonStyle,
   EmbedBuilder,
   Events,
+  Message,
+  TextChannel,
 } from "discord.js";
 
 import { CustomClient } from "~/client";
@@ -12,110 +14,109 @@ import { Flags, isFlagEnabled } from "~/utils/flags";
 import { logger } from "~/utils/logger";
 import { extractUrls } from "~/utils/url";
 
+interface DiscordConfig {
+  config: {
+    id: number;
+    organizationId: number;
+    isMonitoringLinks: boolean;
+    moderatorUsernames: string[];
+    guildId: string;
+    feedChannelId: string | null;
+    isFeedEnabled: boolean;
+    responseAction: "REACTION" | "NOTIFY";
+    moderatorChannelId: string | null;
+  } | null;
+}
+
+const fetchDiscordConfig = async (guildId: string): Promise<DiscordConfig> => {
+  return chainpatrol.fetch<DiscordConfig>({
+    method: "POST",
+    path: ["v2", "internal", "getDiscordConfig"],
+    body: { guildId },
+  });
+};
+
+const createNotificationEmbed = (message: Message, url: string) => {
+  const messageLink = `https://discord.com/channels/${message.guildId}/${message.channelId}/${message.id}`;
+
+  const embed = new EmbedBuilder()
+    .setColor(0xff0000)
+    .setTitle("⚠️ Suspicious Link Detected")
+    .setDescription(`A potentially harmful link was detected in <#${message.channelId}>`)
+    .addFields(
+      { name: "Link", value: `\`${url}\`` },
+      { name: "Posted by", value: `<@${message.author.id}>` },
+    )
+    .setTimestamp();
+
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setLabel("Jump to Message")
+      .setStyle(ButtonStyle.Link)
+      .setURL(messageLink),
+  );
+
+  return { embed, row };
+};
+
+const handleBlockedUrl = async (
+  message: Message,
+  url: string,
+  config: DiscordConfig["config"],
+) => {
+  if (!config) return;
+
+  if (config.responseAction === "REACTION") {
+    await message.react("🚨");
+    return;
+  }
+
+  if (config.responseAction === "NOTIFY" && config.moderatorChannelId) {
+    const moderatorChannel = await message.guild?.channels.fetch(
+      config.moderatorChannelId,
+    );
+    if (moderatorChannel?.isTextBased()) {
+      const { embed, row } = createNotificationEmbed(message, url);
+      await moderatorChannel.send({
+        embeds: [embed],
+        components: [row],
+      });
+    }
+  }
+};
+
+const isValidMessage = (message: Message): boolean => {
+  return !message.author.bot && !!message.guildId;
+};
+
+const isValidConfig = (config: DiscordConfig["config"], channelId: string): boolean => {
+  if (!config?.isMonitoringLinks) return false;
+  if (config.feedChannelId && config.feedChannelId !== channelId) return false;
+  return true;
+};
+
 export default (client: CustomClient) => {
   logger.info("MessageCreate listener loaded.");
 
-  client.on(Events.MessageCreate, async (interaction) => {
-    if (interaction.author.bot) {
-      return;
-    }
-
-    const guildId = interaction.guildId;
-    const channelId = interaction.channelId;
-
-    if (!guildId) {
-      return;
-    }
+  client.on(Events.MessageCreate, async (message) => {
+    if (!isValidMessage(message)) return;
 
     const connectionStatus = await ChainPatrolApiClient.fetchDiscordGuildStatus({
-      guildId,
+      guildId: message.guildId!,
     });
 
-    if (!connectionStatus || !connectionStatus.connected) {
-      return;
-    }
+    if (!connectionStatus?.connected) return;
 
-    const slug = connectionStatus.organizationSlug;
+    const discordConfig = await fetchDiscordConfig(message.guildId!);
+    if (!isValidConfig(discordConfig.config, message.channelId)) return;
 
-    const discordConfig = await chainpatrol.fetch<{
-      config: {
-        id: number;
-        organizationId: number;
-        isMonitoringLinks: boolean;
-        moderatorUsernames: string[];
-        guildId: string;
-        feedChannelId: string | null;
-        isFeedEnabled: boolean;
-        responseAction: "REACTION" | "NOTIFY";
-        moderatorChannelId: string | null;
-      } | null;
-    }>({
-      method: "POST",
-      path: ["v2", "internal", "getDiscordConfig"],
-      body: { guildId },
-    });
-
-    if (!discordConfig?.config?.isMonitoringLinks) {
-      return;
-    }
-
-    if (
-      discordConfig.config.feedChannelId &&
-      discordConfig.config.feedChannelId !== channelId
-    ) {
-      return;
-    }
-
-    const content = interaction.content;
-
-    const possibleUrls = extractUrls(content);
-
-    if (!possibleUrls) {
-      return;
-    }
+    const possibleUrls = extractUrls(message.content);
+    if (!possibleUrls) return;
 
     for (const url of possibleUrls) {
-      const response = await chainpatrol.asset.check({
-        content: url,
-      });
+      const response = await chainpatrol.asset.check({ content: url });
       if (response.status === "BLOCKED") {
-        if (discordConfig.config.responseAction === "REACTION") {
-          await interaction.react("🚨");
-        } else if (
-          discordConfig.config.responseAction === "NOTIFY" &&
-          discordConfig.config.moderatorChannelId
-        ) {
-          const moderatorChannel = await interaction.guild?.channels.fetch(
-            discordConfig.config.moderatorChannelId,
-          );
-          if (moderatorChannel?.isTextBased()) {
-            const messageLink = `https://discord.com/channels/${guildId}/${channelId}/${interaction.id}`;
-
-            const embed = new EmbedBuilder()
-              .setColor(0xff0000)
-              .setTitle("⚠️ Suspicious Link Detected")
-              .setDescription(
-                `A potentially harmful link was detected in <#${channelId}>`,
-              )
-              .addFields(
-                { name: "Link", value: `\`${url}\`` },
-                { name: "Posted by", value: `<@${interaction.author.id}>` },
-              )
-              .setTimestamp();
-
-            const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-              new ButtonBuilder()
-                .setLabel("Jump to Message")
-                .setStyle(ButtonStyle.Link)
-                .setURL(messageLink),
-            );
-
-            await moderatorChannel.send({
-              embeds: [embed],
-              components: [row],
-            });
-          }
-        }
+        await handleBlockedUrl(message, url, discordConfig.config);
         return;
       }
     }


### PR DESCRIPTION
# Enhanced Discord Bot Security Features

Added a new `linkmonitoring` subcommand to the setup command that allows server administrators to monitor channels for suspicious links. The implementation includes:

- Interactive button confirmation flow for enabling monitoring
- Permission checks to ensure only users with Administrator or Manage Server permissions can enable monitoring
- Storage of monitored channels in the ChainPatrol configuration

Refactored the command structure to use separate handler functions for each subcommand, improving code organization and maintainability.

Enhanced the message monitoring system to support two response modes when suspicious links are detected:
- Reaction mode: adds a 🚨 reaction to flagged messages
- Notification mode: sends detailed alerts to a designated moderator channel with message link and user information

Added proper error handling throughout the implementation to provide clear feedback to users when operations fail.