### PR TITLE
Add feed/monitoring flags to response typing

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -19,9 +19,11 @@ export type DiscordGuildStatusResponseType = {
   connected: boolean;
   guildId?: string;
   channelId?: string;
-  organizationName: string;
-  organizationUrl: string;
-  organizationSlug: string;
+  organizationName?: string;
+  organizationUrl?: string;
+  organizationSlug?: string;
+  isFeedEnabled?: boolean;
+  isMonitoringLinks?: boolean;
 };
 
 enum ChainPatrolApiUri {


### PR DESCRIPTION
Updated the `DiscordGuildStatusResponseType` interface to make organization fields optional and added new boolean flags.

- Made `organizationName`, `organizationUrl`, and `organizationSlug` fields optional by adding `?` to their type definitions
- Added two new optional boolean fields:
  - `isFeedEnabled?: boolean`
  - `isMonitoringLinks?: boolean`

---

- This is technically deprecated code that was left in with the old message monitoring system from years ago. Updated it to match the current schema for the endpoint it is calling. 

- No actual errors functionally, but should remove a type error noise. 