### PR TITLE
Fix /setup status to display feed channel

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -482,19 +482,35 @@ async function handleStatus(interaction: CommandInteraction) {
         isMonitoringAllChannels || monitoredChannels.includes(currentChannelId);
       const isModeratorChannel =
         discordConfig?.config?.moderatorChannelId === currentChannelId;
+      const feedChannelId = discordConfig?.config?.feedChannelId;
+      const isFeedEnabled = discordConfig?.config?.isFeedEnabled;
 
       let channelStatus = "";
+
+      if (isFeedEnabled && feedChannelId) {
+        channelStatus += `📢 Posting alerts to <#${feedChannelId}>\n`;
+      }
+
       if (isMonitoringAllChannels) {
         channelStatus += "🔍 All channels are being monitored for links.\n";
-      } else if (isMonitoredChannel) {
-        channelStatus += "🔍 This channel is actively monitored for links.\n";
+      } else if (monitoredChannels.length > 0) {
+        const monitoredChannelMentions = monitoredChannels
+          .map((id) => `<#${id}>`)
+          .join(", ");
+        channelStatus += `🔍 Monitoring channels: ${monitoredChannelMentions}\n`;
+        if (isMonitoredChannel) {
+          channelStatus += "  └ This channel is actively monitored.\n";
+        }
       }
+
       if (isModeratorChannel) {
         channelStatus += "👮 This channel is set as the moderator channel.\n";
+      } else if (discordConfig?.config?.moderatorChannelId) {
+        channelStatus += `👮 Moderator channel: <#${discordConfig.config.moderatorChannelId}>\n`;
       }
 
       await interaction.editReply({
-        content: `✅ This server is connected to ChainPatrol.\nOrganization: ${response.organizationName}\n\n${channelStatus}`,
+        content: `✅ This server is connected to ChainPatrol.\nOrganization: ${response.organizationName}\n\n${channelStatus || "No channels configured yet."}`,
       });
     } else {
       await interaction.editReply({

--- a/src/listeners/message-create.ts
+++ b/src/listeners/message-create.ts
@@ -137,13 +137,13 @@ export default (client: CustomClient) => {
     }
 
     const discordConfig = await fetchDiscordConfig(message.guildId!);
-    
+
     if (!shouldMonitorChannel(discordConfig.config, message.channelId)) {
       return;
     }
 
     const possibleUrls = extractUrls(message.content);
-    
+
     if (!possibleUrls) return;
 
     posthog.capture({
@@ -159,9 +159,11 @@ export default (client: CustomClient) => {
 
     for (const url of possibleUrls) {
       const response = await chainpatrol.asset.check({ content: url });
-      
+
       if (response.status === "BLOCKED") {
-        logger.info(`Blocked URL detected - Guild: ${message.guildId}, Channel: ${message.channelId}, Action: ${discordConfig.config?.responseAction}`);
+        logger.info(
+          `Blocked URL detected - Guild: ${message.guildId}, Channel: ${message.channelId}, Action: ${discordConfig.config?.responseAction}`,
+        );
         posthog.capture({
           distinctId: message.guildId!,
           event: "link_blocked",

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,5 @@
 import pino from "pino";
+
 import { env } from "~/env";
 
 export type Logger = pino.Logger;
@@ -28,10 +29,7 @@ function createLogger({
   }
 
   // Log to BetterStack in production
-  if (
-    env.NODE_ENV === "production" &&
-    env.BETTERSTACK_SOURCE_TOKEN
-  ) {
+  if (env.NODE_ENV === "production" && env.BETTERSTACK_SOURCE_TOKEN) {
     targets.push({
       level: "info",
       target: "@logtail/pino",
@@ -50,7 +48,7 @@ function createLogger({
 
   return pino(
     { level, name, redact },
-    targets.length > 0 ? pino.transport({ targets }) : undefined
+    targets.length > 0 ? pino.transport({ targets }) : undefined,
   );
 }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -2,13 +2,14 @@ export function defangUrl(url: string) {
   return url.replaceAll(".", "(dot)");
 }
 
-export const URL_REGEX = /(?:https?:\/\/)?(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{2,}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)/gi;
+export const URL_REGEX =
+  /(?:https?:\/\/)?(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{2,}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)/gi;
 
 export function extractUrls(str: string) {
   const matches = str.match(URL_REGEX);
   if (!matches) return null;
-  
-  return matches.map(url => {
+
+  return matches.map((url) => {
     if (!url.match(/^https?:\/\//i)) {
       return `https://${url}`;
     }


### PR DESCRIPTION
The `/setup status` command now shows the configured feed channel, all monitored channels, and the moderator channel in the status output.