### PR TITLE
Include organizationSlug in Discord report.create payload

### DIFF
--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -294,8 +294,10 @@ export async function execute(
         };
 
         try {
+          const guildStatus = guildId ? await getDiscordGuildStatus(guildId) : null;
           const response = await chainpatrol.report.create({
             discordGuildId: guildId ?? undefined,
+            organizationSlug: guildStatus?.organizationSlug ?? undefined,
             externalReporter: externalUser,
             title,
             description,


### PR DESCRIPTION
## Summary
- include `organizationSlug` in Discord `/report` submission payloads
- derive the slug from `getDiscordGuildStatus` right before calling `report.create`
- keep existing `discordGuildId` so resolution can use both identifiers during debugging

## Test plan
- [x] Run `yarn format`
- [ ] In Discord, submit `/report` and confirm report creation succeeds
- [ ] Verify server logs show payload includes both `discordGuildId` and `organizationSlug`
- [ ] Compare behavior against Telegram report submissions

Made with [Cursor](https://cursor.com)