### PR TITLE
ENG-4550: Add auto-ban pipeline for blocked Discord user IDs

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -64,6 +64,13 @@ export const data = new SlashCommandBuilder()
     subcommand
       .setName("ignore")
       .setDescription("ignores the current channel from monitoring"),
+  )
+  .addSubcommand((subcommand) =>
+    subcommand
+      .setName("autoban")
+      .setDescription(
+        "toggles auto-ban of blocked Discord users detected in monitored channels",
+      ),
   );
 
 export async function execute(interaction: CommandInteraction) {
@@ -97,6 +104,9 @@ export async function execute(interaction: CommandInteraction) {
       break;
     case "ignore":
       await handleIgnore(interaction);
+      break;
+    case "autoban":
+      await handleAutoBan(interaction);
       break;
   }
 }
@@ -520,6 +530,7 @@ async function handleStatus(interaction: CommandInteraction) {
           moderatorChannelId: string | null;
           monitoredChannels: string[];
           excludedChannels: string[];
+          isAutoBanEnabled: boolean;
         } | null;
       }>({
         method: "POST",
@@ -566,6 +577,7 @@ async function handleStatus(interaction: CommandInteraction) {
           ? "Moderation is currently active across all channels the bot can access. Run `/setup moderation` in a channel if you want to scope monitoring."
           : "Moderation is active only in the configured scoped channels. Run `/setup moderation` in a channel to add or remove it from the scope."
         : `Finish moderation setup in dashboard: ${dashboardLink}`;
+      const autoBanStatus = config?.isAutoBanEnabled ? "Enabled" : "Disabled";
       const setupSummary = [
         "**Connection**",
         `- Status: Connected`,
@@ -581,6 +593,9 @@ async function handleStatus(interaction: CommandInteraction) {
         `- Configured: ${hasModerationConfig ? "Yes" : "No"}`,
         `- Project ID: ${projectIdStatus}`,
         `- Moderator channel: ${moderatorChannel}`,
+        "",
+        "**Auto-Ban**",
+        `- ${autoBanStatus}`,
         "",
         "**Feed**",
         `- ${feedStatus}`,
@@ -792,6 +807,111 @@ async function handleIgnore(interaction: CommandInteraction) {
     logger.error("Error setting up channel ignore:", error);
     await interaction.reply({
       content: "❌ There was an error setting up channel ignore. Please try again later.",
+      ephemeral: true,
+    });
+  }
+}
+
+async function handleAutoBan(interaction: CommandInteraction) {
+  if (!interaction.guildId) {
+    await interaction.reply({
+      content: "This command can only be used in a server.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  if (
+    !interaction.memberPermissions?.has(PermissionFlagsBits.Administrator) &&
+    !interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)
+  ) {
+    await interaction.reply({
+      content:
+        "❌ You need Administrator or Manage Server permissions to configure auto-ban.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  try {
+    const currentConfig = await chainpatrol.fetch<{
+      config: {
+        isAutoBanEnabled: boolean;
+      } | null;
+    }>({
+      method: "POST",
+      path: ["v2", "internal", "getDiscordConfig"],
+      body: { guildId: interaction.guildId },
+    });
+
+    const isCurrentlyEnabled = currentConfig?.config?.isAutoBanEnabled ?? false;
+
+    const toggleButton = new ButtonBuilder()
+      .setCustomId("toggle_autoban")
+      .setLabel(isCurrentlyEnabled ? "Disable Auto-Ban" : "Enable Auto-Ban")
+      .setStyle(isCurrentlyEnabled ? ButtonStyle.Danger : ButtonStyle.Success);
+
+    const cancelButton = new ButtonBuilder()
+      .setCustomId("cancel_autoban")
+      .setLabel("Cancel")
+      .setStyle(ButtonStyle.Secondary);
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      toggleButton,
+      cancelButton,
+    );
+
+    const statusText = isCurrentlyEnabled ? "**enabled**" : "**disabled**";
+    const response = await interaction.reply({
+      content: `Auto-ban is currently ${statusText}.\n\nWhen enabled, the bot will automatically ban Discord users that are on ChainPatrol's blocklist when their IDs are detected in monitored channels. Unknown user IDs will be reported to ChainPatrol for review.\n\nThe bot requires the **Ban Members** permission to use this feature.`,
+      components: [row],
+      ephemeral: true,
+    });
+
+    const collector = response.createMessageComponentCollector({
+      componentType: ComponentType.Button,
+      time: 60000,
+    });
+
+    collector.on("collect", async (i) => {
+      if (i.customId === "toggle_autoban") {
+        const newValue = !isCurrentlyEnabled;
+
+        await chainpatrol.fetch({
+          method: "POST",
+          path: ["v2", "internal", "updateDiscordConfig"],
+          body: {
+            guildId: interaction.guildId,
+            isAutoBanEnabled: newValue,
+          },
+        });
+
+        await i.update({
+          content: newValue
+            ? "✅ Auto-ban has been **enabled**. The bot will now automatically ban blocked Discord users detected in monitored channels."
+            : "✅ Auto-ban has been **disabled**.",
+          components: [],
+        });
+      } else {
+        await i.update({
+          content: "❌ Auto-ban setup cancelled.",
+          components: [],
+        });
+      }
+    });
+
+    collector.on("end", async (collected) => {
+      if (collected.size === 0) {
+        await interaction.editReply({
+          content: "❌ Auto-ban setup timed out. Please try again.",
+          components: [],
+        });
+      }
+    });
+  } catch (error) {
+    logger.error("Error setting up auto-ban:", error);
+    await interaction.reply({
+      content: "❌ There was an error setting up auto-ban. Please try again later.",
       ephemeral: true,
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ const client = new CustomClient({
     GatewayIntentBits.Guilds,
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.MessageContent,
+    GatewayIntentBits.GuildModeration,
   ],
 });
 

--- a/src/listeners/message-create.ts
+++ b/src/listeners/message-create.ts
@@ -11,6 +11,7 @@ import {
 
 import { CustomClient } from "~/client";
 import { ChainPatrolApiClient, chainpatrol } from "~/utils/api";
+import { extractDiscordUserIds, formatDiscordUserAssetUrl } from "~/utils/discord-user";
 import { logger } from "~/utils/logger";
 import { moderateText } from "~/utils/moderation";
 import { posthog } from "~/utils/posthog";
@@ -32,6 +33,7 @@ interface DiscordConfig {
     moderatorChannelId: string | null;
     monitoredChannels: string[];
     excludedChannels?: string[];
+    isAutoBanEnabled: boolean;
   } | null;
 }
 
@@ -180,6 +182,140 @@ const handleModerationFlag = async (
   }
 };
 
+const createAutoBanEmbed = (message: Message, userId: string) => {
+  const messageLink = `https://discord.com/channels/${message.guildId}/${message.channelId}/${message.id}`;
+  const userProfileUrl = formatDiscordUserAssetUrl(userId);
+
+  const embed = new EmbedBuilder()
+    .setColor(0xff0000)
+    .setTitle("🔨 Auto-Ban Executed")
+    .setDescription(
+      `A blocked Discord user was detected and banned from <#${message.channelId}>`,
+    )
+    .addFields(
+      { name: "Banned User", value: `<@${userId}> (${userId})` },
+      { name: "Profile", value: userProfileUrl },
+      { name: "Reported by", value: `<@${message.author.id}>` },
+    )
+    .setTimestamp();
+
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setLabel("Jump to Message")
+      .setStyle(ButtonStyle.Link)
+      .setURL(messageLink),
+  );
+
+  return { embed, row };
+};
+
+const handleAutoBan = async (
+  message: Message,
+  userId: string,
+  config: DiscordConfig["config"],
+) => {
+  if (!config || !message.guild) return;
+
+  try {
+    await message.guild.members.ban(userId, {
+      reason: "Blocked by ChainPatrol (auto-ban)",
+    });
+
+    logger.info(
+      {
+        autoban: {
+          event: "discord_user_auto_banned",
+          guildId: message.guildId,
+          channelId: message.channelId,
+          bannedUserId: userId,
+          reportedBy: message.author.id,
+        },
+      },
+      "Auto-banned blocked Discord user",
+    );
+
+    posthog.capture({
+      distinctId: message.guildId!,
+      event: "discord_user_auto_banned",
+      properties: {
+        guildId: message.guildId,
+        channelId: message.channelId,
+        bannedUserId: userId,
+        reportedBy: message.author.id,
+      },
+    });
+
+    if (config.moderatorChannelId) {
+      const moderatorChannel = await message.guild.channels.fetch(
+        config.moderatorChannelId,
+      );
+      if (moderatorChannel?.isTextBased()) {
+        const { embed, row } = createAutoBanEmbed(message, userId);
+        await moderatorChannel.send({
+          embeds: [embed],
+          components: [row],
+        });
+      }
+    }
+  } catch (error) {
+    logger.error(
+      {
+        autoban: {
+          event: "discord_user_auto_ban_failed",
+          guildId: message.guildId,
+          bannedUserId: userId,
+        },
+        error,
+      },
+      "Failed to auto-ban Discord user",
+    );
+  }
+};
+
+const handleAutoBanReport = async (message: Message, userId: string) => {
+  const userAssetUrl = formatDiscordUserAssetUrl(userId);
+
+  try {
+    await chainpatrol.report.create({
+      discordGuildId: message.guildId ?? undefined,
+      externalReporter: {
+        platform: "discord",
+        platformIdentifier: message.author.id,
+        avatarUrl: message.author.displayAvatarURL(),
+        displayName: `${message.author.username}#${message.author.discriminator}`,
+      },
+      title: `Discord User Report: ${userId}`,
+      description: `Auto-reported Discord user <@${userId}> (ID: ${userId}) detected in channel <#${message.channelId}>.`,
+      contactInfo: "",
+      assets: [{ content: userAssetUrl, status: "BLOCKED" }],
+    });
+
+    logger.info(
+      {
+        autoban: {
+          event: "discord_user_auto_reported",
+          guildId: message.guildId,
+          userId: userId,
+          reportedBy: message.author.id,
+        },
+      },
+      "Auto-reported unknown Discord user",
+    );
+  } catch (error) {
+    logger.error(
+      {
+        autoban: {
+          event: "discord_user_auto_report_failed",
+          guildId: message.guildId,
+          userId: userId,
+        },
+        error,
+      },
+      "Failed to auto-report Discord user",
+    );
+  }
+};
+
 const isValidMessage = (message: Message): boolean => {
   return !message.author.bot && !!message.guildId;
 };
@@ -192,7 +328,12 @@ const shouldMonitorChannel = (
   config: DiscordConfig["config"],
   channelId: string,
 ): boolean => {
-  if (!config?.isMonitoringLinks && !config?.moderationMonitoringEnabled) return false;
+  if (
+    !config?.isMonitoringLinks &&
+    !config?.moderationMonitoringEnabled &&
+    !config?.isAutoBanEnabled
+  )
+    return false;
   if (
     config.monitoredChannels.length > 0 &&
     !config.monitoredChannels.includes(channelId)
@@ -360,44 +501,93 @@ export default (client: CustomClient) => {
       );
     }
 
-    if (!discordConfig.config?.isMonitoringLinks) {
-      return;
-    }
+    if (discordConfig.config?.isMonitoringLinks) {
+      const possibleUrls = extractUrls(message.content);
 
-    const possibleUrls = extractUrls(message.content);
-
-    if (!possibleUrls) return;
-
-    posthog.capture({
-      distinctId: message.guildId!,
-      event: "link_checked",
-      properties: {
-        guildId: message.guildId,
-        channelId: message.channelId,
-        userId: message.author.id,
-        linkCount: possibleUrls.length,
-      },
-    });
-
-    for (const url of possibleUrls) {
-      const response = await chainpatrol.asset.check({ content: url });
-
-      if (response.status === "BLOCKED") {
-        logger.info(
-          `Blocked URL detected - Guild: ${message.guildId}, Channel: ${message.channelId}, Action: ${discordConfig.config?.responseAction}`,
-        );
+      if (possibleUrls) {
         posthog.capture({
           distinctId: message.guildId!,
-          event: "link_blocked",
+          event: "link_checked",
           properties: {
             guildId: message.guildId,
             channelId: message.channelId,
             userId: message.author.id,
-            url: url,
+            linkCount: possibleUrls.length,
           },
         });
-        await handleBlockedUrl(message, url, discordConfig.config);
-        return;
+
+        for (const url of possibleUrls) {
+          const response = await chainpatrol.asset.check({ content: url });
+
+          if (response.status === "BLOCKED") {
+            logger.info(
+              `Blocked URL detected - Guild: ${message.guildId}, Channel: ${message.channelId}, Action: ${discordConfig.config?.responseAction}`,
+            );
+            posthog.capture({
+              distinctId: message.guildId!,
+              event: "link_blocked",
+              properties: {
+                guildId: message.guildId,
+                channelId: message.channelId,
+                userId: message.author.id,
+                url: url,
+              },
+            });
+            await handleBlockedUrl(message, url, discordConfig.config);
+            return;
+          }
+        }
+      }
+    }
+
+    if (!discordConfig.config?.isAutoBanEnabled) {
+      return;
+    }
+
+    const detectedUserIds = extractDiscordUserIds(message.content).filter(
+      (id) => id !== message.author.id,
+    );
+
+    if (detectedUserIds.length === 0) {
+      return;
+    }
+
+    posthog.capture({
+      distinctId: message.guildId!,
+      event: "discord_user_ids_detected",
+      properties: {
+        guildId: message.guildId,
+        channelId: message.channelId,
+        userId: message.author.id,
+        detectedCount: detectedUserIds.length,
+      },
+    });
+
+    for (const userId of detectedUserIds) {
+      const assetUrl = formatDiscordUserAssetUrl(userId);
+
+      try {
+        const checkResponse = await chainpatrol.asset.check({
+          content: assetUrl,
+        });
+
+        if (checkResponse.status === "BLOCKED") {
+          await handleAutoBan(message, userId, discordConfig.config);
+        } else if (checkResponse.status === "UNKNOWN") {
+          await handleAutoBanReport(message, userId);
+        }
+      } catch (error) {
+        logger.error(
+          {
+            autoban: {
+              event: "discord_user_check_failed",
+              guildId: message.guildId,
+              userId,
+            },
+            error,
+          },
+          "Failed to check Discord user asset",
+        );
       }
     }
   });

--- a/src/utils/discord-user.ts
+++ b/src/utils/discord-user.ts
@@ -1,0 +1,31 @@
+const MENTION_REGEX = /<@!?(\d{17,20})>/g;
+
+const PROFILE_LINK_REGEX = /https?:\/\/(?:www\.)?discord\.com\/users\/(\d{17,20})/gi;
+
+const RAW_SNOWFLAKE_REGEX = /(?<![\/\w])(\d{17,20})(?!\w)/g;
+
+export function extractDiscordUserIds(content: string): string[] {
+  const ids = new Set<string>();
+
+  for (const match of content.matchAll(MENTION_REGEX)) {
+    ids.add(match[1]);
+  }
+
+  for (const match of content.matchAll(PROFILE_LINK_REGEX)) {
+    ids.add(match[1]);
+  }
+
+  const strippedContent = content
+    .replace(MENTION_REGEX, "")
+    .replace(PROFILE_LINK_REGEX, "");
+
+  for (const match of strippedContent.matchAll(RAW_SNOWFLAKE_REGEX)) {
+    ids.add(match[1]);
+  }
+
+  return Array.from(ids);
+}
+
+export function formatDiscordUserAssetUrl(userId: string): string {
+  return `https://discord.com/users/${userId}`;
+}


### PR DESCRIPTION
## Summary

- Adds `extractDiscordUserIds` utility to detect Discord user IDs from messages (mentions, profile links, raw snowflakes)
- Extends `message-create.ts` with auto-ban pipeline: when `isAutoBanEnabled` is set, detected user IDs are checked against ChainPatrol — BLOCKED users are banned, UNKNOWN users are reported
- Adds `/setup autoban` subcommand for admins to toggle the feature per guild
- Adds `GuildModeration` intent for ban-related gateway events
- Shows auto-ban status in `/setup status` output

Requested by Arbitrum (Ricardo) who currently manually bans Discord user IDs posted by community members each day.

Depends on the chainpatrol-web PR for `isAutoBanEnabled` field on `DiscordConfig`.

Linear: [ENG-4550](https://linear.app/chainpatrol/issue/ENG-4550)

## Test plan

- [ ] Verify `/setup autoban` shows current status and toggles correctly
- [ ] Verify `/setup status` displays auto-ban status
- [ ] Verify bot detects Discord user IDs in messages (mentions, links, raw snowflakes)
- [ ] Verify blocked user IDs trigger auto-ban with moderator channel notification
- [ ] Verify unknown user IDs create reports in ChainPatrol
- [ ] Verify message author's own ID is excluded from detection
- [ ] Verify auto-ban pipeline is skipped when `isAutoBanEnabled` is false
- [ ] Verify existing link monitoring and moderation flows are unaffected

Made with [Cursor](https://cursor.com)